### PR TITLE
Update Cargo.toml homepage and repository

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ authors = [
 readme = "README.md"
 keywords = ["environment", "env", "dotenv", "settings", "config"]
 license = "MIT"
-homepage = "https://github.com/purpliminal/rust-dotenv"
-repository = "https://github.com/purpliminal/rust-dotenv"
+homepage = "https://github.com/apiraino/rust-dotenv"
+repository = "https://github.com/apiraino/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]


### PR DESCRIPTION
Cargo should link to this repo so people can find it from https://crates.io/crates/dotenv